### PR TITLE
Correct typos in filename and docs of CarouselWithTextControl.tsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-debug.log*
 yarn-error.log*
 yarn.lock
 vercel.json
+package-lock.json

--- a/app/docs/components/carousel/carousel.mdx
+++ b/app/docs/components/carousel/carousel.mdx
@@ -1,31 +1,28 @@
-import {
-  DefaultCarousel,
-  DefaultCarouselCode,
-} from "./variant/DefaultCarousel";
-import { StaticCarousel, StaticCarouselCode } from "./variant/StaticCarousel";
+import { DefaultCarousel, DefaultCarouselCode } from "./variant/DefaultCarousel"
+import { StaticCarousel, StaticCarouselCode } from "./variant/StaticCarousel"
 import {
   CarouselWithCustomControlIcon,
   CarouselWithCustomControlIconCode,
-} from "./variant/CarouselWithCustomControlIcon";
+} from "./variant/CarouselWithCustomControlIcon"
 import {
-  CarousellWithTextControll,
-  CarousellWithTextControllCode,
-} from "./variant/CarousellWithTextControll";
+  CarouselWithTextControl,
+  CarouselWithTextControlCode,
+} from "./variant/CarouselWithTextControl"
 import {
   CarouselWithIndicator,
   CarouselWithIndicatorCode,
-} from "./variant/CarouselWithIndicator";
+} from "./variant/CarouselWithIndicator"
 import {
   MultipleCarousel,
   MultipleCarouselCode,
-} from "./variant/MultipleCarousel";
+} from "./variant/MultipleCarousel"
 
-import { carouselDataApi } from "./carouselApi";
+import { carouselDataApi } from "./carouselApi"
 
-import CodePreview from "~/components/CodePreview";
-import CssThemePreview from "~/components/CssThemePreview";
-import ComponentApi from "~/components/ComponentApi";
-import { useTheme } from "~/src/Keep/ThemeContex";
+import CodePreview from "~/components/CodePreview"
+import CssThemePreview from "~/components/CssThemePreview"
+import ComponentApi from "~/components/ComponentApi"
+import { useTheme } from "~/src/Keep/ThemeContex"
 
 ## Table of Contents
 
@@ -35,7 +32,7 @@ A Carousel component is a user interface element commonly found in web and mobil
 
 Default Carousel component allows you to display a series of images, content, or media items in a rotating manner. It is often used to showcase multiple items in a limited space, allowing users to view different items by sliding or swiping through them.
 
-<CodePreview github="Carousel" code={DefaultCarouselCode}>
+<CodePreview github='Carousel' code={DefaultCarouselCode}>
   <DefaultCarousel />
 </CodePreview>
 
@@ -43,23 +40,23 @@ Default Carousel component allows you to display a series of images, content, or
 
 A Static Carousel is a type of carousel component that displays a sequence of items without providing any indicators or navigation controls for users to manually switch between items. Instead, the items in a static carousel automatically transition or scroll to the next item at a predefined interval.
 
-<CodePreview github="Carousel" code={StaticCarouselCode}>
+<CodePreview github='Carousel' code={StaticCarouselCode}>
   <StaticCarousel />
 </CodePreview>
 
-## Carousel With Text Controll
+## Carousel With Text Control
 
 A Carousel with Text Control is a carousel component that includes textual navigation controls, typically in the form of `Next` and `Previous` buttons.
 
-<CodePreview github="Carousel" code={CarousellWithTextControllCode}>
-  <CarousellWithTextControll />
+<CodePreview github='Carousel' code={CarouselWithTextControlCode}>
+  <CarouselWithTextControl />
 </CodePreview>
 
-## Carousel With Custom Controll Icon
+## Carousel With Custom Control Icon
 
 A Carousel with Custom Control Icons is a carousel component that provides navigation controls with customized icons for moving between items. By using `leftControl` and `rightControl` props, we can add custom controls.
 
-<CodePreview github="Carousel" code={CarouselWithCustomControlIconCode}>
+<CodePreview github='Carousel' code={CarouselWithCustomControlIconCode}>
   <CarouselWithCustomControlIcon />
 </CodePreview>
 
@@ -67,7 +64,7 @@ A Carousel with Custom Control Icons is a carousel component that provides navig
 
 The IndicatorsType prop allows you to choose from different types of indicators. By using `indicatorsType` props as `dots`, `rings`, `bars`, `squares`, or `squareRing`, based on your design preferences.
 
-<CodePreview github="Carousel" code={CarouselWithIndicatorCode}>
+<CodePreview github='Carousel' code={CarouselWithIndicatorCode}>
   <CarouselWithIndicator />
 </CodePreview>
 
@@ -75,7 +72,7 @@ The IndicatorsType prop allows you to choose from different types of indicators.
 
 A Multiple Carousel is a user interface component that allows you to display multiple carousels on a single page or screen.
 
-<CodePreview github="Carousel" code={MultipleCarouselCode}>
+<CodePreview github='Carousel' code={MultipleCarouselCode}>
   <MultipleCarousel />
 </CodePreview>
 

--- a/app/docs/components/carousel/variant/CarouselWithTextControl.tsx
+++ b/app/docs/components/carousel/variant/CarouselWithTextControl.tsx
@@ -1,41 +1,41 @@
-"use client";
-import Image from "next/image";
-import { Carousel } from "~/src";
+"use client"
+import Image from "next/image"
+import { Carousel } from "~/src"
 
-const CarousellWithTextControll = () => {
+const CarouselWithTextControl = () => {
   return (
-    <div className="h-56 w-full sm:h-64 xl:h-80 2xl:h-96">
-      <Carousel leftControl="Prev" rightControl="Next" showControls={true}>
+    <div className='h-56 w-full sm:h-64 xl:h-80 2xl:h-96'>
+      <Carousel leftControl='Prev' rightControl='Next' showControls={true}>
         <Image
-          src="https://images.prismic.io/staticmania/ecd45179-4b86-4a34-b245-0078e022db5a_1.png?auto=compress,format"
-          alt="slider-1"
+          src='https://images.prismic.io/staticmania/ecd45179-4b86-4a34-b245-0078e022db5a_1.png?auto=compress,format'
+          alt='slider-1'
           height={400}
           width={910}
         />
         <Image
-          src="https://images.prismic.io/staticmania/dee3ff09-3ddc-4340-bc8f-ea0028bb4a61_2.png?auto=compress,format"
-          alt="slider-2"
+          src='https://images.prismic.io/staticmania/dee3ff09-3ddc-4340-bc8f-ea0028bb4a61_2.png?auto=compress,format'
+          alt='slider-2'
           height={400}
           width={910}
         />
         <Image
-          src="https://images.prismic.io/staticmania/a5c7143d-24dd-4531-9f00-243f4eb27e28_3.png?auto=compress,format"
-          alt="slider-3"
+          src='https://images.prismic.io/staticmania/a5c7143d-24dd-4531-9f00-243f4eb27e28_3.png?auto=compress,format'
+          alt='slider-3'
           height={400}
           width={910}
         />
         <Image
-          src="https://images.prismic.io/staticmania/c5cf46a8-b10c-43c8-a60e-6692838cdee1_4.png?auto=compress,format"
-          alt="slider-4"
+          src='https://images.prismic.io/staticmania/c5cf46a8-b10c-43c8-a60e-6692838cdee1_4.png?auto=compress,format'
+          alt='slider-4'
           height={400}
           width={910}
         />
       </Carousel>
     </div>
-  );
-};
+  )
+}
 
-const CarousellWithTextControllCode = `
+const CarouselWithTextControlCode = `
 "use client";
 import Image from "next/image";
 import { Carousel } from "keep-react";
@@ -72,6 +72,6 @@ export const CarouselComponent = () => {
     </div>
   );
 }
-`;
+`
 
-export { CarousellWithTextControll, CarousellWithTextControllCode };
+export { CarouselWithTextControl, CarouselWithTextControlCode }

--- a/public/data/search.json
+++ b/public/data/search.json
@@ -346,12 +346,12 @@
         "id": "#static-carousel"
       },
       {
-        "title": "Carousel With Text Controll",
-        "id": "#carousel-with-text-controll"
+        "title": "Carousel With Text Control",
+        "id": "#carousel-with-text-control"
       },
       {
-        "title": "Carousel With Custom Controll Icon",
-        "id": "#carousel-with-custom-controll-icon"
+        "title": "Carousel With Custom Control Icon",
+        "id": "#carousel-with-custom-control-icon"
       },
       {
         "title": "Carousel With Indicator",


### PR DESCRIPTION
Made the following changes: 

1. The name of the Carousel variant CarousellWithTextControll.tsx changed to CarouselWithTextControl.tsx
2. Rectified spelling mistakes.
3. Added `package-lock.json` in `.gitignore`