### PR TITLE
dropdown items overlapping

### DIFF
--- a/src/components/Floating/Floating.tsx
+++ b/src/components/Floating/Floating.tsx
@@ -121,6 +121,7 @@ export const Floating: FC<FloatingProps> = ({
             top: y ?? ' ',
             left: x ?? ' ',
             minWidth,
+            zIndex: 0
           },
           ...props,
         })}>


### PR DESCRIPTION
#58 
## Dropdown Items Overlapping the Navbar. 

## Issus was:
After showing the dropdown menu if while scrolling the page the dropdown items overlap the navigation bar. This is not appropriate behavior on that.

##  i did change
The dropdown items are shown by the Floating.tsx component. I added into the floating component inline CSS object `style : { zIndex: 0 }`.


## Before
![before](https://github.com/StaticMania/keep-react/assets/49164744/c75c428a-5075-48f8-8509-983baa715d13)

## After
![after](https://github.com/StaticMania/keep-react/assets/49164744/f09d45cf-f33f-41b6-907d-0c4242d30ade)
