### PR TITLE
 Refractor: Removed a depreacated depenedency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log*
 yarn.lock
 vercel.json
 package-lock.json
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/babel__generator": "^7.6.6",
     "@types/mdx": "^2.0.10",
     "@types/node": "^20.9.0",
-    "@types/rc-slider": "^9.3.1",
     "@types/react": "^18.2.22",
     "@types/react-collapse": "^5.0.2",
     "@types/react-datepicker": "^4.15.0",


### PR DESCRIPTION
Removed @types/rc-slider@9.3.1 while rc-slider provides its type definitions.
![image](https://github.com/StaticMania/keep-react/assets/89929036/ec55a7fc-d32d-4ff8-a351-cbd1e5f1ee4c)
