### PR TITLE
Enhance: Change accordion icon plus to cross while accordion panel is open

### DIFF
--- a/app/src/components/Accordion/theme.ts
+++ b/app/src/components/Accordion/theme.ts
@@ -15,7 +15,7 @@ export const accordionTheme: keepAccordionTheme = {
   icon: {
     base: 'transition-transform duration-300',
     rotated: {
-      full: 'rotate-25',
+      full: 'rotate-225',
       half: 'rotate-90',
     },
   },

--- a/app/src/components/Accordion/theme.ts
+++ b/app/src/components/Accordion/theme.ts
@@ -15,7 +15,7 @@ export const accordionTheme: keepAccordionTheme = {
   icon: {
     base: 'transition-transform duration-300',
     rotated: {
-      full: 'rotate-[225deg]',
+      full: 'rotate-[225deg]', // changed 180 to 225 deg
       half: 'rotate-90',
     },
   },

--- a/app/src/components/Accordion/theme.ts
+++ b/app/src/components/Accordion/theme.ts
@@ -15,7 +15,7 @@ export const accordionTheme: keepAccordionTheme = {
   icon: {
     base: 'transition-transform duration-300',
     rotated: {
-      full: 'rotate-45',
+      full: 'rotate-25',
       half: 'rotate-90',
     },
   },

--- a/app/src/components/Accordion/theme.ts
+++ b/app/src/components/Accordion/theme.ts
@@ -15,7 +15,7 @@ export const accordionTheme: keepAccordionTheme = {
   icon: {
     base: 'transition-transform duration-300',
     rotated: {
-      full: 'rotate-180',
+      full: 'rotate-45',
       half: 'rotate-90',
     },
   },

--- a/app/src/components/Accordion/theme.ts
+++ b/app/src/components/Accordion/theme.ts
@@ -15,7 +15,7 @@ export const accordionTheme: keepAccordionTheme = {
   icon: {
     base: 'transition-transform duration-300',
     rotated: {
-      full: 'rotate-225',
+      full: 'rotate-[225deg]',
       half: 'rotate-90',
     },
   },


### PR DESCRIPTION
### What does this PR do?
This is an enhancement in the accordion component icon. Previously, If anyone open the accordion then the plus icon remaining same but now it will gonna be cross icon which is more user friendly.
Fixed #120 

### Type of change
- Accordion Icon styles changes
Screenshots:
Before:
![image](https://github.com/StaticMania/keep-react/assets/77241744/b7a7a1a3-3839-46eb-879e-3a9de2ca0aee)
After:
![image](https://github.com/StaticMania/keep-react/assets/77241744/2a43a900-be84-4069-9bee-9e5154ec6433)

Video: [watch Video](https://jam.dev/c/23e4bc43-d501-43a8-8168-4c7e442f0e02)